### PR TITLE
Potential fix for code scanning alert no. 80: Sensitive data read from GET request

### DIFF
--- a/routes/changePassword.ts
+++ b/routes/changePassword.ts
@@ -10,11 +10,11 @@ import { UserModel } from '../models/user'
 import * as security from '../lib/insecurity'
 
 export function changePassword () {
-  return async ({ query, headers, connection }: Request, res: Response, next: NextFunction) => {
-    const currentPassword = query.current as string
-    const newPassword = query.new as string
+  return async ({ body, headers, connection }: Request, res: Response, next: NextFunction) => {
+    const currentPassword = body.current as string
+    const newPassword = body.new as string
     const newPasswordInString = newPassword?.toString()
-    const repeatPassword = query.repeat
+    const repeatPassword = body.repeat
 
     if (!newPassword || newPassword === 'undefined') {
       res.status(401).send(res.__('Password cannot be empty.'))


### PR DESCRIPTION
Potential fix for [https://github.com/Champmsecurity/juice-shop_Ghas/security/code-scanning/80](https://github.com/Champmsecurity/juice-shop_Ghas/security/code-scanning/80)

To fix the issue, the route handler should be modified to use a POST request instead of a GET request. Sensitive data, such as passwords, should be transmitted in the request body rather than in query parameters. This change involves updating the function to read the `current`, `new`, and `repeat` password values from the request body instead of the query object. Additionally, the route definition in the application should be updated to use POST instead of GET.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
