### PR TITLE
Potential fix for code scanning alert no. 26: Template Object Injection

### DIFF
--- a/routes/dataErasure.ts
+++ b/routes/dataErasure.ts
@@ -70,7 +70,8 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
       const isForbiddenFile: boolean = (filePath.includes('ftp') || filePath.includes('ctf.key') || filePath.includes('encryptionkeys'))
       if (!isForbiddenFile) {
         res.render('dataErasureResult', {
-          ...req.body
+          email: req.body.email,
+          securityAnswer: req.body.securityAnswer
         }, (error, html) => {
           if (!html || error) {
             next(new Error(error.message))
@@ -85,7 +86,8 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
       }
     } else {
       res.render('dataErasureResult', {
-        ...req.body
+        email: req.body.email,
+        securityAnswer: req.body.securityAnswer
       })
     }
   } catch (error) {


### PR DESCRIPTION
Potential fix for [https://github.com/Champmsecurity/juice-shop_Ghas/security/code-scanning/26](https://github.com/Champmsecurity/juice-shop_Ghas/security/code-scanning/26)

To fix the issue, we need to avoid directly passing the user-controlled `req.body` object to the template engine. Instead, we should explicitly construct a new object containing only the necessary properties required by the template. This ensures that no unexpected or malicious properties are injected into the template.

**Steps to fix:**
1. Replace the usage of `{...req.body}` in `res.render` with an explicitly constructed object containing only the required properties (`email` and `securityAnswer`).
2. Ensure that the constructed object does not include any user-controlled properties that could lead to security vulnerabilities.

**Required changes:**
- Modify the `res.render` calls on lines 87 and 88 to use a safe object.
- No new dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
