### PR TITLE
Potential fix for code scanning alert no. 5: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: { $eq: id } }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/Champmsecurity/juice-shop_Ghas/security/code-scanning/5](https://github.com/Champmsecurity/juice-shop_Ghas/security/code-scanning/5)

To fix the issue, the `$where` query should be replaced with a safer alternative that does not involve executing JavaScript code. Instead, use MongoDB's standard query operators, such as `$eq`, to perform the same functionality without relying on `$where`. This eliminates the risk of code injection entirely.

The fix involves:
1. Replacing the `$where` query with a query using `$eq` to match the `orderId` field directly.
2. Ensuring that `id` is properly sanitized and validated before use.

No new dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
